### PR TITLE
DOCSP-7186: Snooty Preview can render more templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "snooty-frontend"]
-	path = snooty-frontend
-	url = https://github.com/mongodb/snooty
-	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = snooty-frontend
 	url = https://github.com/mongodb/snooty
 	branch = master
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "snooty-frontend"]
+	path = snooty-frontend
+	url = https://github.com/mongodb/snooty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "snooty-frontend"]
 	path = snooty-frontend
 	url = https://github.com/mongodb/snooty
+	branch = master

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,48 @@
+# Snooty VS Code
+
+## Setting Up Parser Communication
+
+If you're working on changes to the Snooty VS Code extension, it will be useful to set up your local repo of the [Snooty Parser](https://github.com/mongodb/snooty-parser). Make sure to follow the instructions found [here](https://github.com/mongodb/snooty-parser/blob/master/HACKING.md#developing-snooty) to be able to modify the parser.
+
+Communication between the Snooty extension and the parser are performed via remote procedure calls (RPC) found in the parser's language server. To allow the VS Code extension to communicate to your local repo of the parser, do the following:
+
+1. Press `Cmd` + `Shift` + `P` to open a list of commands.
+2. Run `Preferences: Open Settings (JSON)` to open `settings.json` for VS Code.
+3. Add the following in `settings.json`:
+
+```
+"snooty.languageServerPath": "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/bin/snooty",
+```
+
+## Making Client Requests
+
+RPC calls are made from the extension to the parser using the following:
+```
+client.sendRequest({parameter: argument}, (returnValue) => {
+	// do stuff
+});
+```
+
+## Running the Extension Locally
+
+Press `F5` to run the extension locally. This should open up an Extension Development Host instance of VS Code. Open any docs repo that has a `snooty.toml` file (and pull any remote assets using `make` if it hasn't been done so already).
+
+## Snooty Submodule
+
+Before working on Snooty Preview, it is important to set up the submodule for the [Snooty frontend components](https://github.com/mongodb/snooty).
+
+To set up, run:
+```
+make frontend
+```
+
+## Snooty Preview
+
+Snooty Preview is a feature that allows the user to preview a single page as it would look like on the documentation site, without having to formally build the entire site. Snooty Frontend is used as a submodule to make use of the frontend components needed to render the page. The parser is responsible for passing along the abstract syntax tree (AST) and other data needed by the frontend components.
+
+Snooty Preview can be broken down into the following files:
+
+* `preview.ts`: Contains tasks and commands needed for Snooty Preview's workflow.
+* `webview.ts`: Handles creating a webview panel for the preview page.
+
+More information on Snooty Preview can be found [here](https://github.com/mongodb/snooty/blob/master/HACKING.md#vs-code-extension).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+FRONTEND_DIR=snooty-frontend
+ENV_PROD=.env.production
+
+frontend:
+	git submodule init
+	git submodule update
+	touch ${FRONTEND_DIR}/${ENV_PROD}
+	cd ${FRONTEND_DIR} && ${MAKE} static
+	cd ${FRONTEND_DIR} && npm install

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
 		"compile": "webpack --mode none",
 		"watch": "webpack --mode none --watch",
 		"test": "tsc -p ./ && ./scripts/e2e.sh",
-		"preview": "./snooty-frontend/node_modules/.bin/webpack --config ./snooty-frontend/webpack.config.js --env.PREVIEW_PAGE='true'"
+		"preview": "./snooty-frontend/node_modules/.bin/webpack --config ./snooty-frontend/webpack.config.js"
 	},
 	"dependencies": {
 		"@types/mime": "^2.0.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { Logger } from "./logger";
 import * as util from './common';
 import { ExtensionDownloader } from "./ExtensionDownloader";
-import { startWebview } from "./webview";
+import { registerSnootyPreview } from "./preview";
 
 const EXTENSION_ID = 'i80and.snooty';
 let logger: Logger = null;
@@ -134,37 +134,7 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(getPageAST);
 
-    // Get the project name found in the repo's snooty.toml
-    const getProjectName: vscode.Disposable = vscode.commands.registerCommand('snooty.getProjectName', async () => {
-        return await client.sendRequest("textDocument/get_project_name", {});
-    });
-    context.subscriptions.push(getProjectName);
-
-    // Get the file id of the file currently using Snooty Preview
-    const getPageFileId: vscode.Disposable = vscode.commands.registerCommand('snooty.getPageFileId', async () => {
-        const textDocument: vscode.TextDocument = vscode.window.activeTextEditor.document;
-        const fileName: string = textDocument.fileName;
-        return await client.sendRequest("textDocument/get_page_fileid", {filePath: fileName});
-    });
-    context.subscriptions.push(getPageFileId);
-
-    // Snooty Preview command to open webview panel and display content of page AST
-    const snootyPreview: vscode.Disposable = vscode.commands.registerCommand('snooty.snootyPreview', async () => {
-        const projectName: string = await vscode.commands.executeCommand('snooty.getProjectName');
-        const previewPage: string = await vscode.commands.executeCommand('snooty.getPageFileId');
-
-        // Create task for Snooty Preview
-        const previewBundleTask: vscode.Task = createPreviewBundleTask(context, previewPage, projectName);
-        vscode.tasks.onDidEndTask((e) => {
-            if (e.execution.task === previewBundleTask) {
-                startWebview(context, projectName, previewPage);
-            }
-        });
-
-        await vscode.commands.executeCommand('snooty.getPageAST');
-        await vscode.tasks.executeTask(previewBundleTask);
-    });
-    context.subscriptions.push(snootyPreview);
+    registerSnootyPreview(client, context);
 
     // Shows clickable link to file after hovering over it
     vscode.languages.registerHoverProvider(
@@ -296,28 +266,4 @@ class DocumentLinkProvider implements vscode.DocumentLinkProvider {
                 return vscode.Uri.file(file);
         });
     }
-}
-
-// Create task to run webpack on snooty frontend via npm run preview
-function createPreviewBundleTask(context: vscode.ExtensionContext, previewPage: string, projectName: string): vscode.Task {
-    const envPreviewPage = `--env.PREVIEW_PAGE='${previewPage}'`;
-    const envProjectName = `--env.PROJECT_NAME='${projectName}'`;
-    const task: vscode.Task = new vscode.Task(
-        {type: 'previewProvider'},
-        vscode.TaskScope.Workspace,
-        "Snooty Preview: Webpack Bundle",
-        "snooty"
-    );
-
-    // For testing purposes, we want to see the terminal output
-    task.presentationOptions = {
-        reveal: vscode.TaskRevealKind.Always,
-        panel: vscode.TaskPanelKind.New
-    };
-    task.execution = new vscode.ShellExecution(
-        `npm run preview -- ${envPreviewPage} ${envProjectName}`,
-        { cwd: context.extensionPath }
-    );
-
-    return task;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,16 +134,33 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(getPageAST);
 
-    // Create task for Snooty Preview
-    const previewBundleTask: vscode.Task = createPreviewBundleTask(context);
-    vscode.tasks.onDidEndTask((e) => {
-        if (e.execution.task === previewBundleTask) {
-            startWebview(context);
-        }
+    // Get the project name found in the repo's snooty.toml
+    const getProjectName: vscode.Disposable = vscode.commands.registerCommand('snooty.getProjectName', async () => {
+        return await client.sendRequest("textDocument/get_project_name", {});
     });
+    context.subscriptions.push(getProjectName);
+
+    // Get the file id of the file currently using Snooty Preview
+    const getPageFileId: vscode.Disposable = vscode.commands.registerCommand('snooty.getPageFileId', async () => {
+        const textDocument: vscode.TextDocument = vscode.window.activeTextEditor.document;
+        const fileName: string = textDocument.fileName;
+        return await client.sendRequest("textDocument/get_page_fileid", {filePath: fileName});
+    });
+    context.subscriptions.push(getPageFileId);
 
     // Snooty Preview command to open webview panel and display content of page AST
     const snootyPreview: vscode.Disposable = vscode.commands.registerCommand('snooty.snootyPreview', async () => {
+        const projectName: string = await vscode.commands.executeCommand('snooty.getProjectName');
+        const previewPage: string = await vscode.commands.executeCommand('snooty.getPageFileId');
+
+        // Create task for Snooty Preview
+        const previewBundleTask: vscode.Task = createPreviewBundleTask(context, previewPage, projectName);
+        vscode.tasks.onDidEndTask((e) => {
+            if (e.execution.task === previewBundleTask) {
+                startWebview(context, projectName, previewPage);
+            }
+        });
+
         await vscode.commands.executeCommand('snooty.getPageAST');
         await vscode.tasks.executeTask(previewBundleTask);
     });
@@ -282,20 +299,23 @@ class DocumentLinkProvider implements vscode.DocumentLinkProvider {
 }
 
 // Create task to run webpack on snooty frontend via npm run preview
-function createPreviewBundleTask(context: vscode.ExtensionContext): vscode.Task {
+function createPreviewBundleTask(context: vscode.ExtensionContext, previewPage: string, projectName: string): vscode.Task {
+    const envPreviewPage = `--env.PREVIEW_PAGE='${previewPage}'`;
+    const envProjectName = `--env.PROJECT_NAME='${projectName}'`;
     const task: vscode.Task = new vscode.Task(
         {type: 'previewProvider'},
         vscode.TaskScope.Workspace,
         "Snooty Preview: Webpack Bundle",
         "snooty"
     );
+
     // For testing purposes, we want to see the terminal output
     task.presentationOptions = {
         reveal: vscode.TaskRevealKind.Always,
         panel: vscode.TaskPanelKind.New
     };
     task.execution = new vscode.ShellExecution(
-        `npm run preview`,
+        `npm run preview -- ${envPreviewPage} ${envProjectName}`,
         { cwd: context.extensionPath }
     );
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,62 +1,80 @@
 /* This file contains functions relevant for Snooty Preview */
 
-import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
+import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient";
 import { startWebview } from "./webview";
 
 // Registers Snooty Preview as a usable command
-export function registerSnootyPreview(client: LanguageClient, context: vscode.ExtensionContext): void {
-	const snootyPreview: vscode.Disposable = vscode.commands.registerCommand('snooty.snootyPreview', async () => {
-		const projectName: string = await getProjectName(client);
-		const previewPage: string = await getPageFileId(client);
-	
-		// Create task for Snooty Preview
-		const previewBundleTask: vscode.Task = createPreviewBundleTask(context, previewPage, projectName);
-		vscode.tasks.onDidEndTask((e) => {
-				if (e.execution.task === previewBundleTask) {
-						startWebview(context, projectName, previewPage);
-				}
-		});
-	
-		await vscode.commands.executeCommand('snooty.getPageAST');
-		await vscode.tasks.executeTask(previewBundleTask);
-	});
+export function registerSnootyPreview(
+  client: LanguageClient,
+  context: vscode.ExtensionContext
+): void {
+  const snootyPreview: vscode.Disposable = vscode.commands.registerCommand(
+    "snooty.snootyPreview",
+    async () => {
+      const projectName: string = await getProjectName(client);
+      const previewPage: string = await getPageFileId(client);
 
-	context.subscriptions.push(snootyPreview);
+      // Create task for Snooty Preview
+      const previewBundleTask: vscode.Task = createPreviewBundleTask(
+        context,
+        previewPage,
+        projectName
+      );
+      vscode.tasks.onDidEndTask(e => {
+        6;
+        if (e.execution.task === previewBundleTask) {
+          startWebview(context, projectName, previewPage);
+        }
+      });
+
+      await vscode.commands.executeCommand("snooty.getPageAST");
+      await vscode.tasks.executeTask(previewBundleTask);
+    }
+  );
+
+  context.subscriptions.push(snootyPreview);
 }
 
 // Get the project name of the current repo
 async function getProjectName(client: LanguageClient): Promise<string> {
-	return await client.sendRequest("textDocument/get_project_name", {});
+  return await client.sendRequest("textDocument/get_project_name", {});
 }
 
 // Get the file id of the file currently using Snooty Preview
 async function getPageFileId(client: LanguageClient): Promise<string> {
-	const textDocument: vscode.TextDocument = vscode.window.activeTextEditor.document;
-	const fileName: string = textDocument.fileName;
-	return await client.sendRequest("textDocument/get_page_fileid", {filePath: fileName});
+  const textDocument: vscode.TextDocument =
+    vscode.window.activeTextEditor.document;
+  const fileName: string = textDocument.fileName;
+  return await client.sendRequest("textDocument/get_page_fileid", {
+    filePath: fileName
+  });
 }
 
 // Create task to run webpack on snooty frontend via npm run preview
-function createPreviewBundleTask(context: vscode.ExtensionContext, previewPage: string, projectName: string): vscode.Task {
-	const envPreviewPage = `--env.PREVIEW_PAGE='${previewPage}'`;
-	const envProjectName = `--env.PROJECT_NAME='${projectName}'`;
-	const task: vscode.Task = new vscode.Task(
-			{type: 'previewProvider'},
-			vscode.TaskScope.Workspace,
-			"Snooty Preview: Webpack Bundle",
-			"snooty"
-	);
+function createPreviewBundleTask(
+  context: vscode.ExtensionContext,
+  previewPage: string,
+  projectName: string
+): vscode.Task {
+  const envPreviewPage = `--env.PREVIEW_PAGE='${previewPage}'`;
+  const envProjectName = `--env.PROJECT_NAME='${projectName}'`;
+  const task: vscode.Task = new vscode.Task(
+    { type: "previewProvider" },
+    vscode.TaskScope.Workspace,
+    "Snooty Preview: Webpack Bundle",
+    "snooty"
+  );
 
-	// For testing purposes, we want to see the terminal output
-	task.presentationOptions = {
-			reveal: vscode.TaskRevealKind.Always,
-			panel: vscode.TaskPanelKind.New
-	};
-	task.execution = new vscode.ShellExecution(
-			`npm run preview -- ${envPreviewPage} ${envProjectName}`,
-			{ cwd: context.extensionPath }
-	);
+  // For testing purposes, we want to see the terminal output
+  task.presentationOptions = {
+    reveal: vscode.TaskRevealKind.Always,
+    panel: vscode.TaskPanelKind.New
+  };
+  task.execution = new vscode.ShellExecution(
+    `npm run preview -- ${envPreviewPage} ${envProjectName}`,
+    { cwd: context.extensionPath }
+  );
 
-	return task;
+  return task;
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,62 @@
+/* This file contains functions relevant for Snooty Preview */
+
+import * as vscode from 'vscode';
+import { LanguageClient } from 'vscode-languageclient';
+import { startWebview } from "./webview";
+
+// Registers Snooty Preview as a usable command
+export function registerSnootyPreview(client: LanguageClient, context: vscode.ExtensionContext): void {
+	const snootyPreview: vscode.Disposable = vscode.commands.registerCommand('snooty.snootyPreview', async () => {
+		const projectName: string = await getProjectName(client);
+		const previewPage: string = await getPageFileId(client);
+	
+		// Create task for Snooty Preview
+		const previewBundleTask: vscode.Task = createPreviewBundleTask(context, previewPage, projectName);
+		vscode.tasks.onDidEndTask((e) => {
+				if (e.execution.task === previewBundleTask) {
+						startWebview(context, projectName, previewPage);
+				}
+		});
+	
+		await vscode.commands.executeCommand('snooty.getPageAST');
+		await vscode.tasks.executeTask(previewBundleTask);
+	});
+
+	context.subscriptions.push(snootyPreview);
+}
+
+// Get the project name of the current repo
+async function getProjectName(client: LanguageClient): Promise<string> {
+	return await client.sendRequest("textDocument/get_project_name", {});
+}
+
+// Get the file id of the file currently using Snooty Preview
+async function getPageFileId(client: LanguageClient): Promise<string> {
+	const textDocument: vscode.TextDocument = vscode.window.activeTextEditor.document;
+	const fileName: string = textDocument.fileName;
+	return await client.sendRequest("textDocument/get_page_fileid", {filePath: fileName});
+}
+
+// Create task to run webpack on snooty frontend via npm run preview
+function createPreviewBundleTask(context: vscode.ExtensionContext, previewPage: string, projectName: string): vscode.Task {
+	const envPreviewPage = `--env.PREVIEW_PAGE='${previewPage}'`;
+	const envProjectName = `--env.PROJECT_NAME='${projectName}'`;
+	const task: vscode.Task = new vscode.Task(
+			{type: 'previewProvider'},
+			vscode.TaskScope.Workspace,
+			"Snooty Preview: Webpack Bundle",
+			"snooty"
+	);
+
+	// For testing purposes, we want to see the terminal output
+	task.presentationOptions = {
+			reveal: vscode.TaskRevealKind.Always,
+			panel: vscode.TaskPanelKind.New
+	};
+	task.execution = new vscode.ShellExecution(
+			`npm run preview -- ${envPreviewPage} ${envProjectName}`,
+			{ cwd: context.extensionPath }
+	);
+
+	return task;
+}

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1,11 +1,13 @@
 import * as vscode from "vscode";
 import * as path from 'path';
 
-export function startWebview(context: vscode.ExtensionContext) {
+export function startWebview(context: vscode.ExtensionContext, projectName: string, previewPage: string) {
+		// Choose template. Guarantees the correct fonts are loaded in as well
+		const template = projectName === 'guides' ? 'guides.css' : 'mongodb-docs.css';
 		// Create panel
 		const panel = vscode.window.createWebviewPanel(
 				'snootyPreview', 
-				'Snooty Preview',
+				`Snooty Preview - ${previewPage}`,
 				{
 					preserveFocus: true,
 					viewColumn: vscode.ViewColumn.Beside
@@ -18,7 +20,6 @@ export function startWebview(context: vscode.ExtensionContext) {
 
 		// Set up resource files needed for page to render (bundle and css)
 		// If file does not exist, panel will show empty content
-		// Paths of bundle and css files may change after snooty frontend submodule works
 		const bundlePath = path.join(
 				context.extensionPath, 
 				'snooty-frontend/preview',
@@ -30,7 +31,7 @@ export function startWebview(context: vscode.ExtensionContext) {
 		const cssPath = path.join(
 				context.extensionPath, 
 				'snooty-frontend/static/docs-tools',
-				'guides.css'
+				template
 		);
 		const cssFile = getResource(cssPath);
 		

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1,98 +1,102 @@
 import * as vscode from "vscode";
-import * as path from 'path';
+import * as path from "path";
 
-export function startWebview(context: vscode.ExtensionContext, projectName: string, previewPage: string) {
-		// Choose template. Guarantees the correct fonts are loaded in as well
-		const template = projectName === 'guides' ? 'guides.css' : 'mongodb-docs.css';
-		// Create panel
-		const panel = vscode.window.createWebviewPanel(
-				'snootyPreview', 
-				`Snooty Preview - ${previewPage}`,
-				{
-					preserveFocus: true,
-					viewColumn: vscode.ViewColumn.Beside
-				},
-				{
-						enableScripts: true,
-						retainContextWhenHidden: true,
-				}
-		);
+export function startWebview(
+  context: vscode.ExtensionContext,
+  projectName: string,
+  previewPage: string
+): void {
+  // Choose template. Guarantees the correct fonts are loaded in as well
+  const template = projectName === "guides" ? "guides.css" : "mongodb-docs.css";
+  // Create panel
+  const panel = vscode.window.createWebviewPanel(
+    "snootyPreview",
+    `Snooty Preview - ${previewPage}`,
+    {
+      preserveFocus: true,
+      viewColumn: vscode.ViewColumn.Beside
+    },
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  );
 
-		// Set up resource files needed for page to render (bundle and css)
-		// If file does not exist, panel will show empty content
-		const bundlePath = path.join(
-				context.extensionPath, 
-				'snooty-frontend/preview',
-				'bundle.js'
-		);
-		const bundleFile = getResource(bundlePath);
-		// TODO: Add validation through parser to see which css file to use. 
-		// For testing purposes, only support guides until we get communication between extension and frontend working
-		const cssPath = path.join(
-				context.extensionPath, 
-				'snooty-frontend/static/docs-tools',
-				template
-		);
-		const cssFile = getResource(cssPath);
-		
-		// Assign html content to webview panel
-		panel.webview.html = getWebviewContent(bundleFile, cssFile);
+  // Set up resource files needed for page to render (bundle and css)
+  // If file does not exist, panel will show empty content
+  const bundlePath = path.join(
+    context.extensionPath,
+    "snooty-frontend/preview",
+    "bundle.js"
+  );
+  const bundleFile = getResource(bundlePath);
+  // TODO: Add validation through parser to see which css file to use.
+  // For testing purposes, only support guides until we get communication between extension and frontend working
+  const cssPath = path.join(
+    context.extensionPath,
+    "snooty-frontend/static/docs-tools",
+    template
+  );
+  const cssFile = getResource(cssPath);
+
+  // Assign html content to webview panel
+  panel.webview.html = getWebviewContent(bundleFile, cssFile);
 }
 
 // Takes a path to a file and converts it to a secure resource for webview
 function getResource(path: string): vscode.Uri {
-		const fileUri = vscode.Uri.file(path);
-		return fileUri.with({scheme: 'vscode-resource'});
+  const fileUri = vscode.Uri.file(path);
+  return fileUri.with({ scheme: "vscode-resource" });
 }
 
 // Returns html template used to render preview
 function getWebviewContent(bundleScript: vscode.Uri, css: vscode.Uri): string {
-		return `
-				<!DOCTYPE html>
-				<html lang="en">
-				<head>
-						<meta charSet="utf-8" />
-						<meta httpEquiv="x-ua-compatible" content="ie=edge" />
-						<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-						<meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
-						<meta name="robots" content="index" />
-						<meta name="release" content="1.0" />
-						<meta name="version" content="master" />
-						<meta name="DC.Source" content="https://github.com/mongodb/docs-bi-connector/blob/DOCSP-3279/source/index.txt" />
-						<meta
-								property="og:image"
-								content="http://s3.amazonaws.com/info-mongodb-com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
-						/>
-						<meta
-								property="og:image:secure_url"
-								content="https://webassets.mongodb.com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
-						/>
-						<meta
-								http-equiv="Content-Security-Policy"
-								content="default-src 'none'; 
-								img-src vscode-resource: https: data:; 
-								script-src 'unsafe-eval' vscode-resource: data:; 
-								style-src 'unsafe-inline' vscode-resource: https:;
-								font-src https: vscode-resource:"
-						/>
-						<link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
-						<link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
-						<link
-								rel="search"
-								type="application/opensearchdescription+xml"
-								href="https://docs.mongodb.com/osd.xml"
-								title="MongoDB Help"
-						/>
-						<link href="${css}" rel="stylesheet" type="text/css"/>
-						<style>
-								body {
-										background: white
-								}
-						</style>
-				</head>
-				<body>
-						<div id="app"></div>
-						<script src="${bundleScript}"></script>
-				</body>
-				</html>`;
+  return `
+	<!DOCTYPE html>
+	<html lang="en">
+	<head>
+		<meta charSet="utf-8" />
+		<meta httpEquiv="x-ua-compatible" content="ie=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta name="robots" content="index" />
+		<meta name="release" content="1.0" />
+		<meta name="version" content="master" />
+		<meta name="DC.Source" content="https://github.com/mongodb/docs-bi-connector/blob/DOCSP-3279/source/index.txt" />
+		<meta
+			property="og:image"
+			content="http://s3.amazonaws.com/info-mongodb-com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
+		/>
+		<meta
+			property="og:image:secure_url"
+			content="https://webassets.mongodb.com/_com_assets/cms/mongodb-for-giant-ideas-bbab5c3cf8.png"
+		/>
+		<meta
+			http-equiv="Content-Security-Policy"
+			content="default-src 'none'; 
+			img-src vscode-resource: https: data:; 
+			script-src 'unsafe-eval' vscode-resource: data:; 
+			style-src 'unsafe-inline' vscode-resource: https:;
+			font-src https: vscode-resource:"
+		/>
+		<link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" type="text/css" />
+		<link rel="shortcut icon" href="https://media.mongodb.org/favicon.ico" />
+		<link
+			rel="search"
+			type="application/opensearchdescription+xml"
+			href="https://docs.mongodb.com/osd.xml"
+			title="MongoDB Help"
+		/>
+		<link href="${css}" rel="stylesheet" type="text/css"/>
+		<style>
+			body {
+			background: white
+			}
+		</style>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script src="${bundleScript}"></script>
+	</body>
+	</html>`;
 }


### PR DESCRIPTION
[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-7186)

This PR should be merged after the [PR for the parser](https://github.com/mongodb/snooty-parser/pull/44).

TODO: Perhaps create a [script file](https://github.com/mongodb/snooty-vscode/pull/5#issue-325785296) that'll help set up `snooty-frontend` for new developers