### PR TITLE
DOCSP-7187: Users can preview .rst files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": {
 				"type": "npm",
-				"script": "watch"
+				"script": "compile"
 			}
 		},
 		{

--- a/src/docLinkProvider.ts
+++ b/src/docLinkProvider.ts
@@ -1,71 +1,84 @@
 import * as vscode from "vscode";
-import { LanguageClient, CancellationToken } from 'vscode-languageclient';
+import { LanguageClient, CancellationToken } from "vscode-languageclient";
 
 export class DocumentLinkProvider implements vscode.DocumentLinkProvider {
-	private _client: LanguageClient;
+  private _client: LanguageClient;
 
-	constructor(client: LanguageClient) {
-			this._client = client;
-	}
+  constructor(client: LanguageClient) {
+    this._client = client;
+  }
 
-	// Provides the text document with the ranges for document links
-	provideDocumentLinks(document: vscode.TextDocument, token: CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
-			return this._findDocLinks(document);
-	}
+  // Provides the text document with the ranges for document links
+  provideDocumentLinks(
+    document: vscode.TextDocument,
+    token: CancellationToken
+  ): vscode.ProviderResult<vscode.DocumentLink[]> {
+    return this._findDocLinks(document);
+  }
 
-	// Adds the target uri to the document link
-	async resolveDocumentLink(link: vscode.DocumentLink, token: CancellationToken): Promise<vscode.DocumentLink> {
-			const document = vscode.window.activeTextEditor.document;
-			const text = document.getText(link.range);
-			link.target = await this._findTargetUri(document, text);
-			return link;
-	}
+  // Adds the target uri to the document link
+  async resolveDocumentLink(
+    link: vscode.DocumentLink,
+    token: CancellationToken
+  ): Promise<vscode.DocumentLink> {
+    const document = vscode.window.activeTextEditor.document;
+    const text = document.getText(link.range);
+    link.target = await this._findTargetUri(document, text);
+    return link;
+  }
 
-	// Returns document links found within the current text document
-	private _findDocLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
-			const docText = document.getText();
-			const docRoles = docText.match(/:doc:`.+?`/gs);
+  // Returns document links found within the current text document
+  private _findDocLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
+    const docText = document.getText();
+    const docRoles = docText.match(/:doc:`.+?`/gs);
 
-			if (docRoles === null) return [];
+    if (docRoles === null) return [];
 
-			let doclinks: vscode.DocumentLink[] = [];
-			let docRoleOffsetStart = -1; // Initiated to -1 to accommodate 0th index
+    let doclinks: vscode.DocumentLink[] = [];
+    let docRoleOffsetStart = -1; // Initiated to -1 to accommodate 0th index
 
-			// For every doc role found, find their respective target
-			for (const docRole of docRoles) {
-					docRoleOffsetStart = docText.indexOf(docRole, docRoleOffsetStart + 1);
+    // For every doc role found, find their respective target
+    for (const docRole of docRoles) {
+      docRoleOffsetStart = docText.indexOf(docRole, docRoleOffsetStart + 1);
 
-					// Find target in doc role
-					// Check if target exists in the form :doc:`text <target-name>`
-					let targetMatches = docRole.match(/(?<=<)\S+(?=>)/);
-					// If target not found, target should exist in the form :doc:`target-name`
-					if (targetMatches === null) {
-							targetMatches = docRole.match(/(?<=`)\S+(?=`)/);
-					}
-					const target = targetMatches[0];
-					const targetIndex = docRole.indexOf(target);
+      // Find target in doc role
+      // Check if target exists in the form :doc:`text <target-name>`
+      let targetMatches = docRole.match(/(?<=<)\S+(?=>)/);
+      // If target not found, target should exist in the form :doc:`target-name`
+      if (targetMatches === null) {
+        targetMatches = docRole.match(/(?<=`)\S+(?=`)/);
+      }
+      const target = targetMatches[0];
+      const targetIndex = docRole.indexOf(target);
 
-					// Get range of the target within the scope of the whole text document
-					const targetOffsetStart = docRoleOffsetStart + targetIndex;
-					const targetOffsetEnd = targetOffsetStart + target.length;
+      // Get range of the target within the scope of the whole text document
+      const targetOffsetStart = docRoleOffsetStart + targetIndex;
+      const targetOffsetEnd = targetOffsetStart + target.length;
 
-					doclinks.push({
-							range: new vscode.Range(
-									document.positionAt(targetOffsetStart), 
-									document.positionAt(targetOffsetEnd)
-							)
-					});
-			}
+      doclinks.push({
+        range: new vscode.Range(
+          document.positionAt(targetOffsetStart),
+          document.positionAt(targetOffsetEnd)
+        )
+      });
+    }
 
-			return doclinks;
-	}
+    return doclinks;
+  }
 
-	// Returns the full uri given a target's name
-	private async _findTargetUri(document: vscode.TextDocument, target: string): Promise<vscode.Uri> {
-			return await this._client.sendRequest(
-					"textDocument/resolve", 
-					{fileName: target, docPath: document.uri.path, resolveType: "doc"}).then((file: string) => {
-							return vscode.Uri.file(file);
-			});
-	}
+  // Returns the full uri given a target's name
+  private async _findTargetUri(
+    document: vscode.TextDocument,
+    target: string
+  ): Promise<vscode.Uri> {
+    return await this._client
+      .sendRequest("textDocument/resolve", {
+        fileName: target,
+        docPath: document.uri.path,
+        resolveType: "doc"
+      })
+      .then((file: string) => {
+        return vscode.Uri.file(file);
+      });
+  }
 }

--- a/src/docLinkProvider.ts
+++ b/src/docLinkProvider.ts
@@ -2,6 +2,12 @@ import * as vscode from "vscode";
 import { LanguageClient, CancellationToken } from "vscode-languageclient";
 
 export class DocumentLinkProvider implements vscode.DocumentLinkProvider {
+  /**
+   * Handles creation of document links (https://code.visualstudio.com/api/references/vscode-api#DocumentLink)
+   * for doc roles. Clicking on the target of a document link allows the user to open a text editor with its
+   * corresponding file.
+   */
+
   private _client: LanguageClient;
 
   constructor(client: LanguageClient) {

--- a/src/docLinkProvider.ts
+++ b/src/docLinkProvider.ts
@@ -1,0 +1,71 @@
+import * as vscode from "vscode";
+import { LanguageClient, CancellationToken } from 'vscode-languageclient';
+
+export class DocumentLinkProvider implements vscode.DocumentLinkProvider {
+	private _client: LanguageClient;
+
+	constructor(client: LanguageClient) {
+			this._client = client;
+	}
+
+	// Provides the text document with the ranges for document links
+	provideDocumentLinks(document: vscode.TextDocument, token: CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
+			return this._findDocLinks(document);
+	}
+
+	// Adds the target uri to the document link
+	async resolveDocumentLink(link: vscode.DocumentLink, token: CancellationToken): Promise<vscode.DocumentLink> {
+			const document = vscode.window.activeTextEditor.document;
+			const text = document.getText(link.range);
+			link.target = await this._findTargetUri(document, text);
+			return link;
+	}
+
+	// Returns document links found within the current text document
+	private _findDocLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
+			const docText = document.getText();
+			const docRoles = docText.match(/:doc:`.+?`/gs);
+
+			if (docRoles === null) return [];
+
+			let doclinks: vscode.DocumentLink[] = [];
+			let docRoleOffsetStart = -1; // Initiated to -1 to accommodate 0th index
+
+			// For every doc role found, find their respective target
+			for (const docRole of docRoles) {
+					docRoleOffsetStart = docText.indexOf(docRole, docRoleOffsetStart + 1);
+
+					// Find target in doc role
+					// Check if target exists in the form :doc:`text <target-name>`
+					let targetMatches = docRole.match(/(?<=<)\S+(?=>)/);
+					// If target not found, target should exist in the form :doc:`target-name`
+					if (targetMatches === null) {
+							targetMatches = docRole.match(/(?<=`)\S+(?=`)/);
+					}
+					const target = targetMatches[0];
+					const targetIndex = docRole.indexOf(target);
+
+					// Get range of the target within the scope of the whole text document
+					const targetOffsetStart = docRoleOffsetStart + targetIndex;
+					const targetOffsetEnd = targetOffsetStart + target.length;
+
+					doclinks.push({
+							range: new vscode.Range(
+									document.positionAt(targetOffsetStart), 
+									document.positionAt(targetOffsetEnd)
+							)
+					});
+			}
+
+			return doclinks;
+	}
+
+	// Returns the full uri given a target's name
+	private async _findTargetUri(document: vscode.TextDocument, target: string): Promise<vscode.Uri> {
+			return await this._client.sendRequest(
+					"textDocument/resolve", 
+					{fileName: target, docPath: document.uri.path, resolveType: "doc"}).then((file: string) => {
+							return vscode.Uri.file(file);
+			});
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,11 +5,11 @@ import * as vscode from "vscode";
 import { ServerOptions, Executable, LanguageClient, LanguageClientOptions, CancellationToken } from 'vscode-languageclient';
 import * as mime from "mime";
 import * as open from "open";
-import * as path from 'path';
 import { Logger } from "./logger";
 import * as util from './common';
 import { ExtensionDownloader } from "./ExtensionDownloader";
 import { registerSnootyPreview } from "./preview";
+import { DocumentLinkProvider } from "./docLinkProvider";
 
 const EXTENSION_ID = 'i80and.snooty';
 let logger: Logger = null;
@@ -171,74 +171,5 @@ async function ensureRuntimeDependencies(extension: vscode.Extension<object>, lo
         return downloader.installRuntimeDependencies();
     } else {
         return true;
-    }
-}
-
-class DocumentLinkProvider implements vscode.DocumentLinkProvider {
-    private _client: LanguageClient;
-
-    constructor(client: LanguageClient) {
-        this._client = client;
-    }
-
-    // Provides the text document with the ranges for document links
-    provideDocumentLinks(document: vscode.TextDocument, token: CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
-        return this._findDocLinks(document);
-    }
-
-    // Adds the target uri to the document link
-    async resolveDocumentLink(link: vscode.DocumentLink, token: CancellationToken): Promise<vscode.DocumentLink> {
-        const document = vscode.window.activeTextEditor.document;
-        const text = document.getText(link.range);
-        link.target = await this._findTargetUri(document, text);
-        return link;
-    }
-
-    // Returns document links found within the current text document
-    private _findDocLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
-        const docText = document.getText();
-        const docRoles = docText.match(/:doc:`.+?`/gs);
-
-        if (docRoles === null) return [];
-
-        let doclinks: vscode.DocumentLink[] = [];
-        let docRoleOffsetStart = -1; // Initiated to -1 to accommodate 0th index
-
-        // For every doc role found, find their respective target
-        for (const docRole of docRoles) {
-            docRoleOffsetStart = docText.indexOf(docRole, docRoleOffsetStart + 1);
-
-            // Find target in doc role
-            // Check if target exists in the form :doc:`text <target-name>`
-            let targetMatches = docRole.match(/(?<=<)\S+(?=>)/);
-            // If target not found, target should exist in the form :doc:`target-name`
-            if (targetMatches === null) {
-                targetMatches = docRole.match(/(?<=`)\S+(?=`)/);
-            }
-            const target = targetMatches[0];
-            const targetIndex = docRole.indexOf(target);
-
-            // Get range of the target within the scope of the whole text document
-            const targetOffsetStart = docRoleOffsetStart + targetIndex;
-            const targetOffsetEnd = targetOffsetStart + target.length;
-
-            doclinks.push({
-                range: new vscode.Range(
-                    document.positionAt(targetOffsetStart), 
-                    document.positionAt(targetOffsetEnd)
-                )
-            });
-        }
-
-        return doclinks;
-    }
-
-    // Returns the full uri given a target's name
-    private async _findTargetUri(document: vscode.TextDocument, target: string): Promise<vscode.Uri> {
-        return await this._client.sendRequest(
-            "textDocument/resolve", 
-            {fileName: target, docPath: document.uri.path, resolveType: "doc"}).then((file: string) => {
-                return vscode.Uri.file(file);
-        });
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,33 +108,8 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(clickInclude);
 
-    // Command for getting page ast
-    const getPageAST: vscode.Disposable = vscode.commands.registerCommand('snooty.getPageAST', async () => {
-        const textDocument: vscode.TextDocument = vscode.window.activeTextEditor.document;
-        const fileName: string = textDocument.fileName;
-
-        // Only valid on .txt site pages for now
-        if (!fileName.endsWith(".txt")) {
-            const errorMsg = "ERROR: This command can only be performed on .txt files."
-            vscode.window.showErrorMessage(errorMsg);
-        }
-        else {
-            await client.sendRequest("textDocument/get_page_ast", {filePath: fileName}).then((ast: any) => {
-                // Save page AST as a file
-                const astFilePath = path.resolve(
-                    extension.extensionPath, 
-                    'snooty-frontend/preview',
-                    'page-ast.json'
-                );
-                fs.writeFile(astFilePath, JSON.stringify(ast), (err) => {
-                    if (err) throw err;
-                });
-            });
-        }
-    });
-    context.subscriptions.push(getPageAST);
-
-    registerSnootyPreview(client, context);
+    // Register Snooty Preview as a valid command to run
+    registerSnootyPreview(client, context, extension);
 
     // Shows clickable link to file after hovering over it
     vscode.languages.registerHoverProvider(

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -16,9 +16,7 @@ export function registerSnootyPreview(
     "snooty.snootyPreview",
     async () => {
       const projectName: string = await getProjectName(client);
-      console.log(projectName);
       const previewPage: string = await getPageFileId(client);
-      console.log(previewPage);
 
       // Create task for Snooty Preview
       const previewBundleTask: vscode.Task = createPreviewBundleTask(
@@ -78,7 +76,6 @@ async function getPageAST(
           "snooty-frontend/preview",
           "page-ast.json"
         );
-        console.log(ast);
         fs.writeFile(astFilePath, JSON.stringify(ast), err => {
           if (err) throw err;
         });

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -66,7 +66,7 @@ async function getPageAST(
     vscode.window.activeTextEditor.document;
   const fileName: string = textDocument.fileName;
 
-  if (fileName.endsWith(".txt") || fileName.endsWith(".rst")) {
+  if (hasValidExtension(fileName)) {
     await client
       .sendRequest("textDocument/get_page_ast", { fileName })
       .then((ast: any) => {
@@ -89,6 +89,12 @@ async function getPageAST(
     "ERROR: Snooty Preview command does not support this file type.";
   vscode.window.showErrorMessage(errorMsg);
   return 1;
+}
+
+// Checks fileName if it ends with an extension valid for Snooty Preview
+function hasValidExtension(fileName: string) {
+  const extensions = [".txt", ".rst"];
+  return extensions.some(ext => fileName.endsWith(ext));
 }
 
 // Create task to run webpack on snooty frontend via npm run preview


### PR DESCRIPTION
[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-7187)

* Allows users to preview .rst files as they would with .txt files
* Fixed a bug where previewing an invalid file (.yaml) would preview the previous bundled page
* Missing: tabs pillstrips are tricky to preview without the context of the whole page. Spoke to Sue about this and it might be okay to leave it out for now since most users would probably want to view these kinds of things directly on the page, as opposed to standalone.