### PR TITLE
DOCSP-8978: Refactor & cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,24 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+		},
 		"@types/mime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
 			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+		},
+		"@types/mkdirp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.0.tgz",
+			"integrity": "sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "5.2.7",
@@ -38,8 +52,31 @@
 		"@types/node": {
 			"version": "8.10.58",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.58.tgz",
-			"integrity": "sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==",
+			"integrity": "sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ=="
+		},
+		"@types/vscode": {
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
+			"integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
 			"dev": true
+		},
+		"@types/yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/yauzl-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/yauzl-promise/-/yauzl-promise-2.1.0.tgz",
+			"integrity": "sha512-7PkQ5UtElDsanzjdUQzXnstCqxx6KAOTMURuHwOuqC6YO2WaYQ6ItLnLy3TiEVNQMO/pD+QSOcfnAkeSX4hsTA==",
+			"requires": {
+				"@types/events": "*",
+				"@types/node": "*",
+				"@types/yauzl": "*"
+			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1422,6 +1459,11 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
 			"dev": true
+		},
+		"events-intercept": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/events-intercept/-/events-intercept-2.0.0.tgz",
+			"integrity": "sha1-rb84aBxaSyARxB7kH2GjTLpEiJc="
 		},
 		"evp_bytestokey": {
 			"version": "1.0.3",
@@ -4593,6 +4635,14 @@
 				"rimraf": "^2.6.3"
 			}
 		},
+		"tmp-promise": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.2.tgz",
+			"integrity": "sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==",
+			"requires": {
+				"tmp": "0.1.0"
+			}
+		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -5310,6 +5360,23 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
+			}
+		},
+		"yauzl-clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/yauzl-clone/-/yauzl-clone-1.0.4.tgz",
+			"integrity": "sha1-i8bSk7F8yYgCu77S4onRjnaXyWw=",
+			"requires": {
+				"events-intercept": "^2.0.0"
+			}
+		},
+		"yauzl-promise": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-2.1.3.tgz",
+			"integrity": "sha1-F0Z4RduJ/GWSyph8ouz+6MOBrj0=",
+			"requires": {
+				"yauzl": "^2.9.1",
+				"yauzl-clone": "^1.0.4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -47,11 +47,6 @@
 					"default": null,
 					"description": "Override the path to Snooty. Only required for Snooty developers."
 				},
-				"snooty.updateOnStartup": {
-					"type": "boolean",
-					"default": false,
-					"description": "Update the Snooty language server whenever the extension starts up."
-				},
 				"snooty.trace.server": {
 					"scope": "window",
 					"type": "string",
@@ -116,39 +111,16 @@
 	"runtimeDependencies": [
 		{
 			"description": "Snooty Language Server for macOS (x64)",
-			"url": "https://github.com/mongodb/snooty-parser/releases/download/v0.3.0/snooty-v0.3.0-darwin_x86_64.zip",
+			"platforms": {
+				"x86_64 darwin": "https://github.com/mongodb/snooty-parser/releases/download/v0.3.0/snooty-v0.3.0-darwin_x86_64.zip",
+				"x86_64 linux": "https://github.com/mongodb/snooty-parser/releases/download/v0.3.0/snooty-v0.3.0-linux_x86_64.zip"
+			},
 			"installPath": ".snooty",
-			"platforms": [
-				"darwin"
-			],
-			"architectures": [
-				"x86_64"
-			],
-			"binaries": [
-				"./snooty/snooty"
-			],
-			"installTestPath": "./.snooty/snooty"
-		},
-		{
-			"description": "Snooty Language Server for linux (x64)",
-			"url": "https://github.com/mongodb/snooty-parser/releases/download/v0.3.0/snooty-v0.3.0-linux_x86_64.zip",
-			"installPath": ".snooty",
-			"platforms": [
-				"linux"
-			],
-			"architectures": [
-				"x86_64"
-			],
-			"binaries": [
-				"./snooty/snooty"
-			],
-			"installTestPath": "./.snooty/snooty"
+			"installTestPath": ".snooty/snooty/snooty"
 		}
 	],
 	"scripts": {
-		"update-vscode": "vscode-install",
-		"postinstall": "vscode-install",
-		"vscode:prepublish": "export NODE_ENV=production && make frontend && npm run update-vscode && webpack --mode production",
+		"vscode:prepublish": "export NODE_ENV=production && make frontend && webpack --mode production",
 		"compile": "webpack --mode none",
 		"watch": "webpack --mode none --watch",
 		"test": "tsc -p ./ && ./scripts/e2e.sh",
@@ -156,17 +128,22 @@
 	},
 	"dependencies": {
 		"@types/mime": "^2.0.1",
+		"@types/yauzl-promise": "^2.1.0",
 		"https-proxy-agent": "^2.2.4",
 		"mime": "^2.4.4",
 		"mkdirp": "^0.5.1",
 		"open": "^6.4.0",
-		"tmp": "^0.1.0",
+		"tmp-promise": "^2.0.2",
 		"vscode-languageclient": "^5.2.1",
-		"yauzl": "^2.10.0"
+		"yauzl": "^2.10.0",
+		"yauzl-promise": "^2.1.3"
 	},
 	"devDependencies": {
+		"@types/mkdirp": "^1.0.0",
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^8.10.58",
+		"@types/yauzl": "^2.9.1",
+		"@types/vscode": "^1.34.0",
 		"ts-loader": "^6.2.1",
 		"tslint": "^5.20.0",
 		"typescript": "^3.6.4",

--- a/src/common.ts
+++ b/src/common.ts
@@ -22,10 +22,6 @@ export function getExtensionPath() {
     return extensionPath;
 }
 
-export function isBoolean(obj: any): obj is boolean {
-    return obj === true || obj === false;
-}
-
 export function sum<T>(arr: T[], selector: (item: T) => number): number {
     return arr.reduce((prev, curr) => prev + selector(curr), 0);
 }
@@ -33,12 +29,6 @@ export function sum<T>(arr: T[], selector: (item: T) => number): number {
 /** Retrieve the length of an array. Returns 0 if the array is `undefined`. */
 export function safeLength<T>(arr: T[] | undefined) {
     return arr ? arr.length : 0;
-}
-
-export function buildPromiseChain<T, TResult>(array: T[], builder: (item: T) => Promise<TResult>): Promise<TResult> {
-    return array.reduce(
-        (promise, n) => promise.then(() => builder(n)),
-        Promise.resolve<TResult>(null));
 }
 
 export function execChildProcess(command: string, workingDirectory: string = getExtensionPath()): Promise<string> {
@@ -171,9 +161,9 @@ export function convertNativePathToPosix(pathString: string): string {
 
 /**
  * This function checks to see if a subfolder is part of folder.
- * 
+ *
  * Assumes subfolder and folder are absolute paths and have consistent casing.
- * 
+ *
  * @param subfolder subfolder to check if it is part of the folder parameter
  * @param folder folder to check aganist
  */

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import { WorkspaceConfiguration } from 'vscode';
 
 export class SnootyConfiguration {
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,7 +19,7 @@ export class Logger {
 
     constructor(writer: (message: string) => void, prefix?: string) {
         this._writer = writer;
-        this._prefix = prefix;
+        this._prefix = prefix || "";
     }
 
     private _appendCore(message: string): void {
@@ -36,7 +36,7 @@ export class Logger {
             this._atLineStart = false;
         }
 
-        this.write(message); 
+        this.write(message);
     }
 
     public increaseIndent(): void {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,135 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as crypto from 'crypto';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as util from './common';
-
-const unknown = 'unknown';
-
-/**
- * There is no standard way on Linux to find the distribution name and version.
- * Recently, systemd has pushed to standardize the os-release file. This has
- * seen adoption in "recent" versions of all major distributions.
- * https://www.freedesktop.org/software/systemd/man/os-release.html
- */
-export class LinuxDistribution {
-    public constructor(
-        public name: string,
-        public version: string,
-        public idLike?: string[]) { }
-
-    public static GetCurrent(): Promise<LinuxDistribution> {
-        // Try /etc/os-release and fallback to /usr/lib/os-release per the synopsis
-        // at https://www.freedesktop.org/software/systemd/man/os-release.html.
-        return LinuxDistribution.FromFilePath('/etc/os-release')
-            .catch(() => LinuxDistribution.FromFilePath('/usr/lib/os-release'))
-            .catch(() => Promise.resolve(new LinuxDistribution(unknown, unknown)));
-    }
-
-    public toString(): string {
-        return `name=${this.name}, version=${this.version}`;
-    }
-
-    /**
-     * Returns a string representation of LinuxDistribution that only returns the
-     * distro name if it appears on an allowed list of known distros. Otherwise,
-     * it returns 'other'.
-     */
-    public toTelemetryString(): string {
-        const allowedList = [
-            'antergos', 'arch', 'centos', 'debian', 'deepin', 'elementary', 'fedora',
-            'galliumos', 'gentoo', 'kali', 'linuxmint', 'manjoro', 'neon', 'opensuse',
-            'parrot', 'rhel', 'ubuntu', 'zorin'
-        ];
-
-        if (this.name === unknown || allowedList.indexOf(this.name) >= 0) {
-            return this.toString();
-        }
-        else {
-            // Having a hash of the name will be helpful to identify spikes in the 'other'
-            // bucket when a new distro becomes popular and needs to be added to the
-            // allowed list above.
-            const hash = crypto.createHash('sha256');
-            hash.update(this.name);
-
-            const hashedName = hash.digest('hex');
-
-            return `other (${hashedName})`;
-        }
-    }
-
-    private static FromFilePath(filePath: string): Promise<LinuxDistribution> {
-        return new Promise<LinuxDistribution>((resolve, reject) => {
-            fs.readFile(filePath, 'utf8', (error, data) => {
-                if (error) {
-                    reject(error);
-                }
-                else {
-                    resolve(LinuxDistribution.FromReleaseInfo(data));
-                }
-            });
-        });
-    }
-
-    public static FromReleaseInfo(releaseInfo: string, eol: string = os.EOL): LinuxDistribution {
-        let name = unknown;
-        let version = unknown;
-        let idLike : string[] = null;
-
-        const lines = releaseInfo.split(eol);
-        for (let line of lines) {
-            line = line.trim();
-
-            let equalsIndex = line.indexOf('=');
-            if (equalsIndex >= 0) {
-                let key = line.substring(0, equalsIndex);
-                let value = line.substring(equalsIndex + 1);
-
-                // Strip double quotes if necessary
-                if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-                    value = value.substring(1, value.length - 1);
-                }
-
-                if (key === 'ID') {
-                    name = value;
-                }
-                else if (key === 'VERSION_ID') {
-                    version = value;
-                }
-                else if (key === 'ID_LIKE') {
-                    idLike = value.split(" ");
-                }
-
-                if (name !== unknown && version !== unknown && idLike !== null) {
-                    break;
-                }
-            }
-        }
-
-        return new LinuxDistribution(name, version, idLike);
-    }
-}
 
 export class PlatformInformation {
     public constructor(
         public platform: string,
-        public architecture: string,
-        public distribution: LinuxDistribution = null)
+        public architecture: string)
     {
-    }
-
-    public isWindows(): boolean {
-        return this.platform === 'win32';
-    }
-
-    public isMacOS(): boolean {
-        return this.platform === 'darwin';
-    }
-
-    public isLinux(): boolean {
-        return this.platform === 'linux';
     }
 
     public toString(): string {
@@ -145,45 +24,33 @@ export class PlatformInformation {
             result += this.architecture;
         }
 
-        if (this.distribution) {
-            if (result) {
-                result += ', ';
-            }
-
-            result += this.distribution.toString();
-        }
-
         return result;
     }
 
     public static GetCurrent(): Promise<PlatformInformation> {
         let platform = os.platform();
         let architecturePromise: Promise<string>;
-        let distributionPromise: Promise<LinuxDistribution>;
 
         switch (platform) {
             case 'win32':
                 architecturePromise = PlatformInformation.GetWindowsArchitecture();
-                distributionPromise = Promise.resolve(null);
                 break;
 
             case 'darwin':
                 architecturePromise = PlatformInformation.GetUnixArchitecture();
-                distributionPromise = Promise.resolve(null);
                 break;
 
             case 'linux':
                 architecturePromise = PlatformInformation.GetUnixArchitecture();
-                distributionPromise = LinuxDistribution.GetCurrent();
                 break;
 
             default:
                 throw new Error(`Unsupported platform: ${platform}`);
         }
 
-        return Promise.all<any>([architecturePromise, distributionPromise])
-            .then(([arch, distro]) => {
-                return new PlatformInformation(platform, arch, distro);
+        return Promise.all<any>([architecturePromise])
+            .then(([arch]) => {
+                return new PlatformInformation(platform, arch);
             });
     }
 
@@ -198,14 +65,12 @@ export class PlatformInformation {
         });
     }
 
-    private static GetUnixArchitecture(): Promise<string> {
-        return util.execChildProcess('uname -m')
-            .then(architecture => {
-                if (architecture) {
-                    return architecture.trim();
-                }
+    private static async GetUnixArchitecture(): Promise<string> {
+        const architecture = await util.execChildProcess('uname -m');
+        if (architecture) {
+            return architecture.trim();
+        }
 
-                return null;
-            });
+        return "unknown";
     }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,35 +6,32 @@
 'use strict';
 
 import { Url, parse as parseUrl } from 'url';
-import { isBoolean } from './common';
 import HttpsProxyAgent = require('https-proxy-agent');
 
-function getSystemProxyURL(requestURL: Url): string {
+function getSystemProxyURL(requestURL: Url): string | undefined {
     if (requestURL.protocol === 'https:') {
-        return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null;
+        return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || undefined;
     }
-
-    return null;
 }
 
-export function getProxyAgent(requestURL: Url, proxy: string, strictSSL: boolean): any {
+export function getProxyAgent(requestURL: Url, proxy?: string): HttpsProxyAgent | undefined {
     const proxyURL = proxy || getSystemProxyURL(requestURL);
 
     if (!proxyURL) {
-        return null;
+        return undefined;
     }
 
     const proxyEndpoint = parseUrl(proxyURL);
 
-    if (!/^https?:$/.test(proxyEndpoint.protocol)) {
-        return null;
+    if (!/^https?:$/.test(proxyEndpoint.protocol || "")) {
+        return undefined;
     }
 
     const opts = {
-        host: proxyEndpoint.hostname,
+        host: proxyEndpoint.hostname || "",
         port: Number(proxyEndpoint.port),
         auth: proxyEndpoint.auth,
-        rejectUnauthorized: isBoolean(strictSSL) ? strictSSL : true
+        rejectUnauthorized: true
     };
 
     return new HttpsProxyAgent(opts);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
 	"compilerOptions": {
+		"strict": true,
 		"module": "commonjs",
 		"target": "es6",
 		"outDir": "out",
 		"lib": ["es6"],
 		"sourceMap": true,
-		"rootDir": "src"
+		"rootDir": "src",
 	},
 	"exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
* Change TypeScript to operate in strict mode, requiring many type changes.
* Remove strictSSL as an option.
* Remove unused telemetry boilerplate from Microsoft.
* Use more async functions where possible to clean up logic.
* Simplify Package interface.