### PR TITLE
add link checker as a packaged extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
 	"extensionDependencies": [
 		"bungcip.better-toml"
 	],
+	"extensionPack": ["pi-solved.link-checker"],
 	"runtimeDependencies": [
 		{
 			"description": "Snooty Language Server for macOS (x64)",


### PR DESCRIPTION
This adds the [link checker](https://github.com/terakilobyte/link-checker) plugin I developed as a packaged extension with snooty.