### PR TITLE
DOP-3919: Use most recent parser client-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ It also includes an End-to-End test.
 └── package.json // The extension manifest.
 ```
 
+## How to run locally in development
+
+To test out a local build of the Snooty VSCode Extension, run the command `vsce package` at the root. Once successfully compiled, open a Docs Content repo (e.g. `cloud-docs`, `docs-landing`) in a VSCode window and navigate to the `Extensions` panel from the lefthand `Extensions` sidebar button. Click the button at the top of the panel with the ellipses (...) and select `Install from VSIX`. Choose the newly compiled file from your local `snooty-vscode` repo named in the format of `snooty-<version>.vsix`. This should enable your local branch as the extension utilized on your local machine's VSCode.
+
+
 ## Running the Sample
 
 - Run `npm install` in this folder. This installs all necessary npm modules in the client folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"https-proxy-agent": "^2.2.4",
 				"mime": "^2.4.4",
 				"mkdirp": "^0.5.1",
+				"node-fetch": "^3.3.2",
 				"open": "^6.4.0",
 				"tmp-promise": "^2.0.2",
 				"vscode-languageclient": "^5.2.1",
@@ -980,6 +981,14 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -1300,6 +1309,28 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1323,6 +1354,17 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -1946,6 +1988,41 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
 			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
 			"optional": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.13",
@@ -2876,6 +2953,14 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -119,13 +119,13 @@
 	"dependencies": {
 		"@types/mime": "^2.0.1",
 		"@types/yauzl-promise": "^2.1.0",
-		"@vscode/vsce": "^2.21.0",
 		"https-proxy-agent": "^2.2.4",
 		"mime": "^2.4.4",
 		"mkdirp": "^0.5.1",
 		"node-fetch": "^3.3.2",
 		"open": "^6.4.0",
 		"tmp-promise": "^2.0.2",
+		"@vscode/vsce": "^2.21.0",
 		"vscode-languageclient": "^5.2.1",
 		"yauzl": "^2.10.0",
 		"yauzl-promise": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -107,11 +107,6 @@
 	"runtimeDependencies": [
 		{
 			"description": "Snooty Language Server for macOS (x64)",
-			"platforms": {
-				"x86_64 darwin": "https://github.com/mongodb/snooty-parser/releases/download/v0.14.9/snooty-v0.14.9-darwin_x86_64.zip",
-				"x86_64 linux": "https://github.com/mongodb/snooty-parser/releases/download/v0.14.9/snooty-v0.14.9-linux_x86_64.zip",
-				"arm64 darwin": "https://github.com/mongodb/snooty-parser/releases/download/v0.14.9/snooty-v0.14.9-darwin_x86_64.zip"
-			},
 			"installPath": ".snooty",
 			"installTestPath": ".snooty/snooty/snooty"
 		}
@@ -124,12 +119,13 @@
 	"dependencies": {
 		"@types/mime": "^2.0.1",
 		"@types/yauzl-promise": "^2.1.0",
+		"@vscode/vsce": "^2.21.0",
 		"https-proxy-agent": "^2.2.4",
 		"mime": "^2.4.4",
 		"mkdirp": "^0.5.1",
+		"node-fetch": "^3.3.2",
 		"open": "^6.4.0",
 		"tmp-promise": "^2.0.2",
-		"@vscode/vsce": "^2.21.0",
 		"vscode-languageclient": "^5.2.1",
 		"yauzl": "^2.10.0",
 		"yauzl-promise": "^2.1.3"

--- a/src/ExtensionDownloader.ts
+++ b/src/ExtensionDownloader.ts
@@ -61,6 +61,7 @@ export class ExtensionDownloader
             const fileExists = installedParserVersion === packageManager.parserVersion;
             if (fileExists) {
                 installationStage = 'completeSuccess';
+                this.logger.appendLine('Finished!');
                 success = true;
                 return success;
             }
@@ -121,7 +122,7 @@ export class ExtensionDownloader
     }
 }
 
-function readParserVersionFromFile(logger: Logger) {
+export function readParserVersionFromFile(logger: Logger) {
     const basePath = util.getExtensionPath();
     const absolutePath = path.resolve(basePath, 'parser-version.txt');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,11 +168,6 @@ export function deactivate() {
 }
 
 async function ensureRuntimeDependencies(extension: vscode.Extension<object>, logger: Logger): Promise<boolean> {
-    const exists = await util.installFileExists(util.InstallFileType.Lock);
-    if (!exists) {
-        const downloader = new ExtensionDownloader(getOutputChannel(), logger, extension.packageJSON);
-        return downloader.installRuntimeDependencies();
-    } else {
-        return true;
-    }
+    const downloader = new ExtensionDownloader(getOutputChannel(), logger, extension.packageJSON);
+    return downloader.installRuntimeDependencies();
 }

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -16,6 +16,7 @@ import * as util from './common';
 import { Logger } from './logger';
 import { PlatformInformation } from './platform';
 import { getProxyAgent } from './proxy';
+import { readParserVersionFromFile } from './ExtensionDownloader';
 
 // Unix User Executable bitmask
 const S_IXUSR = 0o0100;
@@ -100,10 +101,14 @@ export class PackageManager {
     
         let latestTag = json?.tag_name;
         if (!latestTag) {
+            // If fetch did not work, assume offline and use currently downloaded snooty-parser
+            latestTag = readParserVersionFromFile(logger);
             logger.appendLine('Error accessing newest snooty-parser version.');
-            latestTag = 'v0.14.10';
+            if (!latestTag) {
+                latestTag = 'v0.15.0';
+            }
         }
-        logger.appendLine(`Setting latest snooty-parser version: '${latestTag}' `);
+        logger.appendLine(`Setting snooty-parser version: '${latestTag}'`);
         this.parserVersion = latestTag;
 
         const latestParserReleaseUrl = `https://github.com/mongodb/snooty-parser/releases/download/${latestTag}/snooty-${latestTag}-${platform}_x86_64.zip`;

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -124,7 +124,7 @@ function getNoopStatus(): Status {
 }
 
 function downloadFile(urlString: string, pkg: Package, logger: Logger, status: Status, proxy?: string): Promise<void> {
-    const url = parseUrl(urlString)
+    const url = parseUrl(urlString);
 
     const options: https.RequestOptions = {
         host: url.host,

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -73,7 +73,7 @@ export class PackageManager {
     }
 
     private async downloadPackage(pkg: Package, logger: Logger, status: Status, proxy?: string): Promise<void> {
-        const platform = this.platformInfo.platform;
+        const { platform } = this.platformInfo;
         if (!['darwin', 'linux'].includes(platform)) {
             throw new PackageError(`Unsupported platform: '${platform}'`, pkg);
         }
@@ -156,6 +156,7 @@ function downloadFile(urlString: string, pkg: Package, logger: Logger, status: S
                 if (newLocation) {
                     return resolve(downloadFile(newLocation, pkg, logger, status, proxy));
                 }
+
                 reject(new PackageError("Error getting download location", pkg));
             }
 


### PR DESCRIPTION
### Ticket

[DOP-3919](https://jira.mongodb.org/browse/DOP-3919)

### Notes

On each activation, the Snooty VSCode extension will now check to see if the latest snooty-parser version has changed. If so, it will download this new release dynamically.